### PR TITLE
OP-20665 - Add logs to track session id

### DIFF
--- a/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
+++ b/rosco-manifests/src/main/java/com/netflix/spinnaker/rosco/manifests/ArtifactDownloaderImpl.java
@@ -38,6 +38,14 @@ public final class ArtifactDownloaderImpl implements ArtifactDownloader {
     if (response.getBody() == null) {
       throw new IOException("Failure to fetch artifact: empty response");
     }
+    response.getHeaders().stream()
+        .iterator()
+        .forEachRemaining(
+            s -> {
+              if (s.getName().equalsIgnoreCase("Set-Cookie")) {
+                log.info("\n ***** {} : {}", s.getName(), s.getValue());
+              }
+            });
     return response.getBody().in();
   }
 


### PR DESCRIPTION
This is a temporary change to track session id that gets added by clouddriver during artifacts/fetch call.
